### PR TITLE
fix: resolve TypeScript type error in poems action

### DIFF
--- a/app/actions/poems.ts
+++ b/app/actions/poems.ts
@@ -144,7 +144,10 @@ export async function updatePoem(poemId: string, formData: FormData) {
     
     // Revalidate both old and new poet pages with encoded URLs
     if (oldPoem && oldPoem.author && typeof oldPoem.author === 'object' && 'url' in oldPoem.author) {
-      revalidatePath(`/p/${encodeURIComponent(oldPoem.author.url)}`)
+      const authorUrl = (oldPoem.author as any).url
+      if (typeof authorUrl === 'string') {
+        revalidatePath(`/p/${encodeURIComponent(authorUrl)}`)
+      }
     }
     if (newPoet) {
       revalidatePath(`/p/${encodeURIComponent(newPoet.url)}`)


### PR DESCRIPTION
- Add explicit type assertion for populated author URL
- Add runtime type check to ensure URL is a string

This fixes the build error on Vercel.

🤖 Generated with [Claude Code](https://claude.ai/code)